### PR TITLE
Fix for Product Event Selection

### DIFF
--- a/Events/templates/event_detail.html
+++ b/Events/templates/event_detail.html
@@ -38,7 +38,7 @@
                     </div>
                     <div class="col-lg-6 d-flex justify-content-end">
                         <a 
-                            href="{% url 'product-create' %}"
+                            href="{% url 'product-create-with-event' event.id %}"
                             class="harvestly-nav-btn-primary px-2 d-flex align-items-center justify-content-center"
                         >
                             <h5 class="m-0">Add Product</h5>

--- a/Events/templates/event_detail.html
+++ b/Events/templates/event_detail.html
@@ -32,17 +32,23 @@
         </div>
         <div class="col-md-6 d-flex flex-column">
             <div class="row">
-                <div class="col-lg-6">
-                    <h3>Products for this Market</h3>
-                </div>
-                <div class="col-lg-6 d-flex justify-content-end">
-                    <a 
-                        href="{% url 'product-create' %}"
-                        class="harvestly-nav-btn-primary px-2 d-flex align-items-center justify-content-center"
-                    >
-                        <h5 class="m-0">Add Product</h5>
-                    </a>
-                </div>
+                {% if user.is_authenticated and user.id == event.organizer.id %}
+                    <div class="col-lg-6">
+                        <h3>Products for this Market</h3>
+                    </div>
+                    <div class="col-lg-6 d-flex justify-content-end">
+                        <a 
+                            href="{% url 'product-create' %}"
+                            class="harvestly-nav-btn-primary px-2 d-flex align-items-center justify-content-center"
+                        >
+                            <h5 class="m-0">Add Product</h5>
+                        </a>
+                    </div>
+                {% else %}
+                    <div class="col">
+                        <h3>Products for this Market</h3>
+                    </div>
+                {% endif %}
             </div>
             <div class="harvestly-scrollable-container">
                 <div class="harvestly-scrollable-content">

--- a/Products/templates/product_create.html
+++ b/Products/templates/product_create.html
@@ -40,8 +40,9 @@
                         {% if event_list %}
                             {% for event in event_list %}
                                 <div
+                                    id="harvestly-event-option-{{ event.id }}"
                                     class="harvestly-scrollable-item flex-column"
-                                    onclick="selectEvent(this, '{{ event.pk }}')"
+                                    onclick="selectEvent(this, '{{ event.id }}')"
                                 >
                                     <h4 class="mb-2">{{ event.name|title }}</h4>
                                     <h5 class="text-muted m-0">{{ event.start_time|format_date_range:event.end_time }}</h5>

--- a/Products/templates/product_create.html
+++ b/Products/templates/product_create.html
@@ -80,7 +80,6 @@
 
 <script>
     let initialEventID = {% if event_id %}"{{ event_id }}"{% else %}null{% endif %};
-    console.log(initialEventID);
 </script>
 {% load static %}
 <script src="{% static 'js/harvestlySelect.js' %}"></script>

--- a/Products/templates/product_create.html
+++ b/Products/templates/product_create.html
@@ -78,6 +78,10 @@
     {% endif %}
 </div>
 
+<script>
+    let initialEventID = {% if event_id %}"{{ event_id }}"{% else %}null{% endif %};
+    console.log(initialEventID);
+</script>
 {% load static %}
 <script src="{% static 'js/harvestlySelect.js' %}"></script>
 

--- a/Products/templates/product_update.html
+++ b/Products/templates/product_update.html
@@ -6,43 +6,61 @@
     <h3 class="subtitle">Edit Product Details</h3>
     <form method="post">
         {% csrf_token %}
-        <div class="row mt-4 mb-5">
-            <div class="col-md-6 mb-1">
-                <!-- TODO make image updateable -->
-                {% load static %}
-                <img class="rounded" src="{% static 'img/product_placeholder.png' %}" alt="Product Image" width="100%">
+        <div class="row pt-4 mb-2">
+            <div class="col-md-6 harvestly-form-item">
+                {{ form.name.label }}
+                {{ form.name }}
             </div>
-            <div class="col-md-6 align-self-center">
-                <div class="harvestly-form-item">
-                    {{ form.name.label }}
-                    {{ form.name }}
+            <div class="col-md-6 harvestly-form-item">
+                {{ form.price.label }}
+                {{ form.price }}
+            </div>
+        </div>
+        <div class="row pt-2 mb-2">
+            <div class="col-md-6 d-flex flex-column">
+                <div class="row mb-2">
+                    <div class="col harvestly-form-item">
+                        {{ form.quantity.label }}
+                        {{ form.quantity }}
+                    </div>
                 </div>
-                <div class="harvestly-form-item">
-                    {{ form.description.label }}
-                    {{ form.description }}
+                <div class="row pt-2">
+                    <div class="col harvestly-form-item">
+                        {{ form.description.label }}
+                        {{ form.description }}
+                    </div>
                 </div>
-                <div class="harvestly-form-item">
-                    {{ form.price.label }}
-                    {{ form.price }}
-                </div>
-                <div class="harvestly-form-item">
-                    {{ form.quantity.label }}
-                    {{ form.quantity }}
-                </div>
-                <div class="d-flex justify-content-end mt-2">
-                    <a
-                    class="harvestly-nav-btn-secondary mx-1 py-2 d-flex justify-content-center align-items-center"
-                    href="{% url 'product-details' product.id %}"
-                >
-                    <h4 class="m-0">Cancel</h4>
-                </a>
-                    <button class="harvestly-nav-btn-primary justify-content-center d-flex mx-1 py-2" type="submit">
-                        <h4 class="m-0">Submit</h4>
-                    </button>
+            </div>
+            <div class="col-md-6 harvestly-form-item">
+                {{ form.product_event.label }}
+                <input type="hidden" name="{{ form.product_event.name }}" id="product-event" value=""/>
+                <div class="harvestly-scrollable-container m-0"> 
+                    {% load filters %}
+                    <div class="harvestly-scrollable-content">
+                        {% if event_list %}
+                            {% for event in event_list %}
+                                <div
+                                    class="harvestly-scrollable-item flex-column"
+                                    onclick="selectEvent(this, '{{ event.pk }}')"
+                                >
+                                    <h4 class="mb-2">{{ event.name|title }}</h4>
+                                    <h5 class="text-muted m-0">{{ event.start_time|format_date_range:event.end_time }}</h5>
+                                    <h5 class="text-muted m-0">{{ event.location|title }}</h5>
+                                </div>
+                            {% endfor %}
+                        {% else %}
+                            <div class="d-flex align-items-center justify-content-center">
+                                <h4 class="text-muted">You must join a market before adding products to it.</h4>
+                            </div>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="justify-content-center">  </div>
+        <div class="d-flex justify-content-end pt-2">
+            <a class="harvestly-nav-btn-secondary d-flex justify-content-center align-items-center mr-2" href="{% url 'products' %}">Cancel</a>
+            <input class="harvestly-nav-btn-primary" type="submit" value="Update Product" />
+        </div>
     </form>
 </div>
 {%endblock %}

--- a/Products/templates/product_update.html
+++ b/Products/templates/product_update.html
@@ -40,8 +40,9 @@
                         {% if event_list %}
                             {% for event in event_list %}
                                 <div
+                                    id="harvestly-event-option-{{ event.id }}"
                                     class="harvestly-scrollable-item flex-column"
-                                    onclick="selectEvent(this, '{{ event.pk }}')"
+                                    onclick="selectEvent(this, '{{ event.id }}')"
                                 >
                                     <h4 class="mb-2">{{ event.name|title }}</h4>
                                     <h5 class="text-muted m-0">{{ event.start_time|format_date_range:event.end_time }}</h5>
@@ -63,4 +64,12 @@
         </div>
     </form>
 </div>
+
+
+<script>
+    let initialEventID = {% if product.product_event %}"{{ product.product_event.id }}"{% else %}null{% endif %};
+</script>
+{% load static %}
+<script src="{% static 'js/harvestlySelect.js' %}"></script>
+
 {%endblock %}

--- a/Products/urls.py
+++ b/Products/urls.py
@@ -8,6 +8,7 @@ from . import views
 urlpatterns = [
     path("", views.ProductList.as_view(), name="products"),
     path("new", views.ProductCreate.as_view(), name="product-create"),
+    path("new/<int:event_id>", views.ProductCreate.as_view(), name="product-create-with-event"),
     path("details/<int:pk>", views.ProductDetail.as_view(), name="product-details"),
     path("edit/<int:pk>", views.ProductUpdate.as_view(), name="product-update"),
     path("delete/<int:pk>", views.ProductDelete.as_view(), name="product-delete"),

--- a/Products/views.py
+++ b/Products/views.py
@@ -66,10 +66,13 @@ class ProductCreate(LoginRequiredMixin, CreateView):
 
         # Set event id attribute on form resubmission
         f_kwargs = super().get_form_kwargs()
-        event_id = f_kwargs["data"].get("product_event")
+        form_data = f_kwargs.get("data")
 
-        if event_id:
-            context["event_id"] = event_id
+        if form_data:
+            event_id = form_data.get("product_event")
+            
+            if event_id:
+                context["event_id"] = event_id
 
         return context
 

--- a/Products/views.py
+++ b/Products/views.py
@@ -57,7 +57,7 @@ class ProductCreate(LoginRequiredMixin, CreateView):
         #   supported in this version of Django.
 
         context = super().get_context_data(**kwargs)
-        context["event_list"] = Event.objects.all()     # TODO update to be only the objects the user has access to
+        context["event_list"] = Event.objects.filter(organizer=self.request.user)
 
         return context
 
@@ -91,7 +91,11 @@ class ProductUpdate(LoginRequiredMixin, UpdateView):
             raise PermissionDenied()
         
         form = self.form_class(instance=product)
-        return render(request, self.template_name, {"form": form, "product": product})
+        return render(request, self.template_name, {
+            "form": form,
+            "product": product,
+            "event_list": Event.objects.filter(organizer=request.user)
+        })
 
 
     def post(self, request, pk):

--- a/Products/views.py
+++ b/Products/views.py
@@ -48,7 +48,6 @@ class ProductCreate(LoginRequiredMixin, CreateView):
 
         return reverse("product-details", kwargs={"pk": self.object.pk})
     
-
     def get_context_data(self, **kwargs):
         """ Include list of events in context data """
         
@@ -58,6 +57,19 @@ class ProductCreate(LoginRequiredMixin, CreateView):
 
         context = super().get_context_data(**kwargs)
         context["event_list"] = Event.objects.filter(organizer=self.request.user)
+
+        # Set initial event ID value (when redirected from event details page, or reload)
+        event_id = self.kwargs.get("event_id")
+        if event_id:
+            context["event_id"] = event_id
+            return context
+
+        # Set event id attribute on form resubmission
+        f_kwargs = super().get_form_kwargs()
+        event_id = f_kwargs["data"].get("product_event")
+
+        if event_id:
+            context["event_id"] = event_id
 
         return context
 

--- a/static/js/harvestlySelect.js
+++ b/static/js/harvestlySelect.js
@@ -1,7 +1,33 @@
+
+// Runs when page is loaded
+document.addEventListener("DOMContentLoaded", function() {
+    // check if initial event is set
+    try {
+        if(initialEventID !== undefined && initialEventID !== null) {
+            // get initially selected option element
+            let elementID = `harvestly-event-option-${initialEventID}`;
+            let element = document.getElementById(elementID);
+            
+            // select event element and update product-event value
+            element.classList.add("selected-event")
+            document.getElementById("product-event").value = initialEventID;
+        }
+    }
+    catch(error) {
+        console.log("Unable to set initial event selection:", error)
+    }
+});
+
 function selectEvent(element, id) {
     if(element.classList.contains("selected-event")) {
         element.classList.remove("selected-event");
-        document.getElementById("product-event").value = null;
+
+        try{
+            document.getElementById("product-event").value = null;
+        }
+        catch(error) {
+            console.log("Unable to update event selection. There must be a 'product-event' field:", error);
+        }
     }
     else {
         // deselect all others
@@ -11,6 +37,12 @@ function selectEvent(element, id) {
         });
 
         element.classList.add("selected-event");
-        document.getElementById("product-event").value = id;
+
+        try{
+            document.getElementById("product-event").value = id;
+        }
+        catch(error) {
+            console.log("Unable to update event selection. There must be a 'product-event' field:", error);
+        }
     }
 }


### PR DESCRIPTION
* A user can now only associate products with events for which they are the organizer
* When the product create form needs to be resubmitted, the event selection will remain
* When redirected from event details page, the event selection will be filled in by default
* Only users who organize a market can see the `Add Product` button